### PR TITLE
Refactor routing to use useNavigate and fix redirect paths

### DIFF
--- a/frontend/src/component/Cart/Cart.js
+++ b/frontend/src/component/Cart/Cart.js
@@ -5,10 +5,11 @@ import { useSelector, useDispatch } from "react-redux";
 import { addItemsToCart, removeItemsFromCart } from "../../actions/cartAction";
 import { Typography } from "@material-ui/core";
 import RemoveShoppingCartIcon from "@material-ui/icons/RemoveShoppingCart";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
-const Cart = ({ history }) => {
+const Cart = () => {
   const dispatch = useDispatch();
+  const navigate = useNavigate(); // Use useNavigate hook
   const { cartItems } = useSelector((state) => state.cart);
 
   const increaseQuantity = (id, quantity, stock) => {
@@ -32,7 +33,7 @@ const Cart = ({ history }) => {
   };
 
   const checkoutHandler = () => {
-    history.push("/login?redirect=shipping");
+    navigate("/login?redirect=/shipping"); // Use navigate to redirect
   };
 
   return (
@@ -40,7 +41,6 @@ const Cart = ({ history }) => {
       {cartItems.length === 0 ? (
         <div className="emptyCart">
           <RemoveShoppingCartIcon />
-
           <Typography>No Product in Your Cart</Typography>
           <Link to="/products">View Products</Link>
         </div>


### PR DESCRIPTION

Title
Refactor Routing to Use useNavigate and Fix Redirect Paths

Description
This pull request refactors the routing implementation in the Cart component to use the useNavigate hook from react-router-dom instead of the deprecated history object. The changes address issues with relative redirect paths and ensure consistency with the current routing practices.

Changes Made:
Replaced history.push with useNavigate in the Cart component.
Updated redirect path in checkoutHandler to use an absolute path (/login?redirect=/shipping) to avoid issues with relative paths.

Why This Change?
The useNavigate hook is the recommended approach for handling navigation in React Router v6 and later. The previous use of history.push was not only outdated but also caused incorrect redirect paths due to relative path handling.

Related Issues:
Issue #98 : Fix incorrect redirect paths in the cart component.
Testing:
Verified that navigation to the login page with a redirect to the shipping page works as expected.
Ensured that the Cart component continues to function correctly with updated routing logic.
Screenshots/GIFs:

![Screenshot 2024-09-12 004639](https://github.com/user-attachments/assets/abda9092-59c7-4e02-8f20-118f47158127)
