### PR TITLE
Fix mongoose query already executed error by cloning query

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -47,13 +47,13 @@ exports.getAllProducts = catchAsyncErrors(async (req, res, next) => {
     .search()
     .filter();
 
-  let products = await apiFeature.query;
+  let products = await apiFeature.query.clone();
 
   let filteredProductsCount = products.length;
 
   apiFeature.pagination(resultPerPage);
 
-  products = await apiFeature.query;
+  products = await apiFeature.query.clone();
 
   res.status(200).json({
     success: true,


### PR DESCRIPTION

This PR fixes the "Query was already executed" Mongoose error in the getAllProducts API.

The issue occurred because the same Mongoose query object was being executed multiple times
for filtering, counting, and pagination.

To resolve this, the query is cloned before each execution using .clone(),
ensuring the query can be safely reused without errors.

Fixed number :#77